### PR TITLE
#45 add strategy optimizer backtesting data and replaced requests wth urllib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ config.json
 tentacles/
 OctoBot.exe
 vaderSentiment
+tests/static/*.data

--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -36,6 +36,7 @@ OCTOBOT_DEV_PHASE = "beta"
 
 DEFAULT_CONFIG_FILE = "config/default_config.json"
 LOGGING_CONFIG_FILE = "config/logging_config.ini"
+STRATEGY_OPTIMIZER_DATA_FOLDER = "tests/static"
 
 GITHUB_RAW_CONTENT_URL = "https://raw.githubusercontent.com"
 GITHUB_API_CONTENT_URL = "https://api.github.com"

--- a/launcher/tools/environment.py
+++ b/launcher/tools/environment.py
@@ -17,17 +17,35 @@ import logging
 import os
 import subprocess
 
-import requests
+import urllib.request
 
 from launcher import CONFIG_FILE, OCTOBOT_GITHUB_REPOSITORY, \
     GITHUB_RAW_CONTENT_URL, OCTOBOT_REFERENCE_BRANCH, DEFAULT_CONFIG_FILE, LOGGING_CONFIG_FILE, \
     CONFIG_DEFAULT_EVALUATOR_FILE, CONFIG_DEFAULT_TRADING_FILE, OCTOBOT_NAME, LINUX_OS_NAME, MAC_OS_NAME, \
-    TENTACLES_PATH, inc_progress, FORCE_BINARY, CONFIG_FILE_SCHEMA_WITH_PATH
+    TENTACLES_PATH, inc_progress, FORCE_BINARY, CONFIG_FILE_SCHEMA_WITH_PATH, STRATEGY_OPTIMIZER_DATA_FOLDER
 from launcher.tools import executor
 from launcher.tools.github import GithubOctoBot
 from launcher.tools.version import OctoBotVersion
 
-FOLDERS_TO_CREATE = ["logs", "backtesting/collector/data"]
+FOLDERS_TO_CREATE = ["logs", "backtesting/collector/data", STRATEGY_OPTIMIZER_DATA_FOLDER]
+STRATEGY_OPTIMIZER_DATA = [
+    "binance_ADA_BTC_20180722_223335.data",
+    "binance_BTC_USDT_20180428_121156.data",
+    "binance_ETH_USDT_20180716_131148.data",
+    "binance_ICX_BTC_20180716_131148.data",
+    "binance_NEO_BTC_20180716_131148.data",
+    "binance_ONT_BTC_20180722_230900.data",
+    "binance_POWR_BTC_20180722_234855.data",
+    "binance_VEN_BTC_20180716_131148.data",
+    "binance_XLM_BTC_20180722_234305.data",
+    "binance_XRB_BTC_20180716_131148.data",
+    "bittrex_ETC_BTC_20180726_210341.data",
+    "bittrex_NEO_BTC_20180722_195942.data",
+    "bittrex_WAX_BTC_20180726_205032.data",
+    "bittrex_XRP_BTC_20180726_210927.data",
+    "bittrex_XVG_BTC_20180726_211225.data"
+]
+
 INSTALL_DOWNLOAD = [
     (
         f"{GITHUB_RAW_CONTENT_URL}/cjhutto/vaderSentiment/master/vaderSentiment/emoji_utf8_lexicon.txt",
@@ -36,30 +54,31 @@ INSTALL_DOWNLOAD = [
         f"{GITHUB_RAW_CONTENT_URL}/cjhutto/vaderSentiment/master/vaderSentiment/vader_lexicon.txt",
         "vaderSentiment/vader_lexicon.txt"),
 ]
+
+OCTOBOT_REPOSITORY_FILES_ROOT = f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}"
+
+INSTALL_DOWNLOAD += [(f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{STRATEGY_OPTIMIZER_DATA_FOLDER}/{data_file}",
+                      f"{STRATEGY_OPTIMIZER_DATA_FOLDER}/{data_file}")
+                     for data_file in STRATEGY_OPTIMIZER_DATA]
+
 FILES_TO_DOWNLOAD = [
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{DEFAULT_CONFIG_FILE}",
-        CONFIG_FILE
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{DEFAULT_CONFIG_FILE}", CONFIG_FILE
     ),
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{DEFAULT_CONFIG_FILE}",
-        DEFAULT_CONFIG_FILE
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{DEFAULT_CONFIG_FILE}", DEFAULT_CONFIG_FILE
     ),
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{CONFIG_FILE_SCHEMA_WITH_PATH}",
-        CONFIG_FILE_SCHEMA_WITH_PATH
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{CONFIG_FILE_SCHEMA_WITH_PATH}", CONFIG_FILE_SCHEMA_WITH_PATH
     ),
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{CONFIG_DEFAULT_EVALUATOR_FILE}",
-        CONFIG_DEFAULT_EVALUATOR_FILE
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{CONFIG_DEFAULT_EVALUATOR_FILE}", CONFIG_DEFAULT_EVALUATOR_FILE
     ),
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{CONFIG_DEFAULT_TRADING_FILE}",
-        CONFIG_DEFAULT_TRADING_FILE
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{CONFIG_DEFAULT_TRADING_FILE}", CONFIG_DEFAULT_TRADING_FILE
     ),
     (
-        f"{GITHUB_RAW_CONTENT_URL}/{OCTOBOT_GITHUB_REPOSITORY}/{OCTOBOT_REFERENCE_BRANCH}/{LOGGING_CONFIG_FILE}",
-        LOGGING_CONFIG_FILE
+        f"{OCTOBOT_REPOSITORY_FILES_ROOT}/{LOGGING_CONFIG_FILE}", LOGGING_CONFIG_FILE
     )
 ]
 
@@ -125,9 +144,7 @@ def ensure_file_environment(file_to_download):
 
         file_name = file_to_dl[1]
         if not os.path.isfile(file_name) and file_name:
-            with open(file_name, "wb") as new_file_from_dl:
-                file_content = requests.get(file_to_dl[0]).text
-                new_file_from_dl.write(file_content.encode())
+            urllib.request.urlretrieve(file_to_dl[0], file_name)
 
 
 def update_tentacles(binary_path, force_install=False):


### PR DESCRIPTION
Add strategy optimizer data when installing OctoBot: these files were missing and forcing to manually download them from OctoBot test folder in order to use the Strategy optimizer with binary version.

Use urlib for files (built in encoding and file writing).